### PR TITLE
feat: reorder lessons on lesson deleted event handler & test

### DIFF
--- a/apis/courses/src/contexts/lessons/application/events/ReorderLessonsOnLessonDeleted.ts
+++ b/apis/courses/src/contexts/lessons/application/events/ReorderLessonsOnLessonDeleted.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@studio/dependency-injection';
+import { DomainEventClass } from '../../../shared/domain/DomainEvent';
+import { LessonWasDeletedEvent } from '../../../lessons/domain/events/LessonWasDeleted';
+import { EventHandler } from '../../../shared/application/EventHandler';
+import { InMemoryAsyncEventBus } from '../../../shared/infrastructure/EventBus/InMemoryAsyncEventBus';
+import { EventBus } from '../../../shared/domain/EventBus';
+import { MongoLessonRepository } from '../../infrastructure/persistance/mongo/MongoLessonRepository';
+import { LessonRepository } from '../../domain/LessonRepository';
+import { CourseId } from '../../../courses/domain/CourseId';
+import { LessonFinder } from '../services/LessonFinder';
+
+@Injectable({
+  dependencies: [MongoLessonRepository, InMemoryAsyncEventBus],
+})
+export class ReorderLessonsOnLessonDeletedHandler extends EventHandler<LessonWasDeletedEvent> {
+  private readonly lessonFinder: LessonFinder;
+
+  public constructor(
+    private readonly lessonRepository: LessonRepository,
+    eventBus?: EventBus
+  ) {
+    super(eventBus);
+    this.lessonFinder = new LessonFinder(lessonRepository);
+  }
+  subscribedTo(): DomainEventClass[] {
+    return [LessonWasDeletedEvent];
+  }
+  async on(domainEvent: LessonWasDeletedEvent): Promise<void> {
+    const { attributes } = domainEvent;
+
+    const courseId = CourseId.of(attributes.courseId);
+
+    const courseLessons = await this.lessonFinder.findByCourseId(courseId);
+
+    const affectedLessons = courseLessons.filter(
+      (lesson, index) => lesson.order.value !== index
+    );
+
+    await Promise.all(
+      affectedLessons.map(async (lesson) => {
+        lesson.moveUp();
+        await this.lessonRepository.update(lesson);
+        this.publishAggregateRootEvents(lesson);
+      })
+    );
+  }
+}

--- a/apis/courses/src/contexts/lessons/application/events/ReorderLessonsOnLessonDeleted.ts
+++ b/apis/courses/src/contexts/lessons/application/events/ReorderLessonsOnLessonDeleted.ts
@@ -40,7 +40,6 @@ export class ReorderLessonsOnLessonDeletedHandler extends EventHandler<LessonWas
       affectedLessons.map(async (lesson) => {
         lesson.moveUp();
         await this.lessonRepository.update(lesson);
-        this.publishAggregateRootEvents(lesson);
       })
     );
   }

--- a/apis/courses/test/unit/contexts/lessons/application/events/ReorderLessonsOnLessonDeleted.spec.ts
+++ b/apis/courses/test/unit/contexts/lessons/application/events/ReorderLessonsOnLessonDeleted.spec.ts
@@ -1,0 +1,72 @@
+import { mock, mockReset } from 'jest-mock-extended';
+import { ReorderLessonsOnLessonDeletedHandler } from '../../../../../../src/contexts/lessons/application/events/ReorderLessonsOnLessonDeleted';
+import { LessonBuilder } from '../../../../../helpers/builders/LessonBuilder';
+import { LessonRepository } from '../../../../../../src/contexts/lessons/domain/LessonRepository';
+import { EventBus } from '../../../../../../src/contexts/shared/domain/EventBus';
+import { LessonWasDeletedEvent } from '../../../../../../src/contexts/lessons/domain/events/LessonWasDeleted';
+import { CourseId } from '../../../../../../src/contexts/courses/domain/CourseId';
+import { LessonOrder } from '../../../../../../src/contexts/lessons/domain/LessonOrder';
+
+describe('Update Course On Lessons Update', () => {
+  const lessonRepository = mock<LessonRepository>();
+  const eventBus = mock<EventBus>();
+
+  beforeEach(() => {
+    mockReset(lessonRepository);
+    mockReset(eventBus);
+  });
+
+  it(`Should reorder lessons on ${LessonWasDeletedEvent.EVENT_NAME}`, async () => {
+    const courseId = CourseId.random();
+    const lesson0 = new LessonBuilder()
+      .withCourseId(courseId)
+      .withOrder(LessonOrder.of(0))
+      .build();
+    const lesson1 = new LessonBuilder()
+      .withCourseId(courseId)
+      .withOrder(LessonOrder.of(1))
+      .build();
+    const lesson2 = new LessonBuilder()
+      .withCourseId(courseId)
+      .withOrder(LessonOrder.of(2))
+      .build();
+    const lesson3 = new LessonBuilder()
+      .withCourseId(courseId)
+      .withOrder(LessonOrder.of(3))
+      .build();
+
+    const event = LessonWasDeletedEvent.fromPrimitives({
+      aggregateId: lesson1.id.value,
+      attributes: {
+        courseId: courseId.value,
+      },
+    });
+
+    const eventHandler = new ReorderLessonsOnLessonDeletedHandler(
+      lessonRepository,
+      eventBus
+    );
+
+    lessonRepository.findByCourseId.mockResolvedValue([
+      lesson0,
+      lesson2,
+      lesson3,
+    ]);
+
+    await expect(eventHandler.on(event)).resolves.not.toThrow();
+
+    expect(lessonRepository.update).toBeCalledTimes(2);
+    expect(lessonRepository.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: lesson2.id,
+        order: LessonOrder.of(1),
+      })
+    );
+    expect(lessonRepository.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: lesson3.id,
+        order: LessonOrder.of(2),
+      })
+    );
+  });
+});


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX19i6hnA6cGqUENqjJWQrlLSVjXHTN5tU%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=CZub-Zf)


Hasta ahora cuando se borraba una lección de un curso, las demás lecciones quedaban en estado inconsistente ya que habia un salto en el orden de las lecciones

Esto a nivel visual para el usuario era transparente ya que las lecciones seguian estando ordenadas y eran accesibles pero a la hora de reordenarlas podia causar comportamientos inesperados.